### PR TITLE
build target support m1 arm64 cpu

### DIFF
--- a/config.gyp
+++ b/config.gyp
@@ -22,6 +22,12 @@
                     'ARCHS': ['x86_64'],
                 }
             },
+            'Release_MACARM64': {
+                'inherit_from': ['Release_MACARM64'],
+                'xcode_settings': {
+                    'ARCHS': ['arm64'],
+                }
+            }
         },
     },
     'targets': [


### PR DESCRIPTION
add configurations for mac m1 arm64 cpu .
build target: Mach-O 64-bit dynamically linked shared library arm64